### PR TITLE
Pack Shenanigans

### DIFF
--- a/src/client/java/dev/enjarai/projectv/ProjectVClient.java
+++ b/src/client/java/dev/enjarai/projectv/ProjectVClient.java
@@ -1,10 +1,17 @@
 package dev.enjarai.projectv;
 
+import dev.enjarai.projectv.pack.PackAdderEvent;
+import dev.enjarai.projectv.resource.BlockVariantTextureGenerator;
 import net.fabricmc.api.ClientModInitializer;
+import net.minecraft.resource.ResourceType;
 
 public class ProjectVClient implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
-
+		PackAdderEvent.EVENT.register((managerType, packs) -> {
+			if (managerType == ResourceType.CLIENT_RESOURCES) {
+				packs.add(BlockVariantTextureGenerator.PACK);
+			}
+		});
 	}
 }

--- a/src/client/java/dev/enjarai/projectv/mixin/client/BakedModelManagerMixin.java
+++ b/src/client/java/dev/enjarai/projectv/mixin/client/BakedModelManagerMixin.java
@@ -18,7 +18,7 @@ public class BakedModelManagerMixin {
 
     @Inject(method = "reload", at = @At("HEAD"))
     private void reloadBlockVariantTextures(ResourceReloader.Synchronizer synchronizer, ResourceManager manager, Profiler prepareProfiler, Profiler applyProfiler, Executor prepareExecutor, Executor applyExecutor, CallbackInfoReturnable<CompletableFuture<Void>> cir) {
-        new BlockVariantTextureGenerator().reload(manager);
+        BlockVariantTextureGenerator.reload(manager);
     }
 
 }

--- a/src/client/java/dev/enjarai/projectv/resource/BlockVariantTextureGenerator.java
+++ b/src/client/java/dev/enjarai/projectv/resource/BlockVariantTextureGenerator.java
@@ -26,26 +26,11 @@ import java.util.*;
  * <p>
  * TODO implement concurrency here?
  */
-public class BlockVariantTextureGenerator implements SimpleSynchronousResourceReloadListener {
+public class BlockVariantTextureGenerator {
     public static final RuntimePack PACK = RuntimePack.create("Project V: Block Variants", ResourceType.CLIENT_RESOURCES);
-    static {
-        PackAdderEvent.EVENT.register((managerType, packs) -> packs.add(PACK));
-    }
     public static final Identifier IDENTIFIER = new Identifier(ProjectV.MOD_ID, "block_variant_generator");
 
-
-    @Override
-    public Identifier getFabricId() {
-        return IDENTIFIER;
-    }
-
-    @Override
-    public Collection<Identifier> getFabricDependencies() {
-        return List.of(ResourceReloadListenerKeys.MODELS, ResourceReloadListenerKeys.TEXTURES);
-    }
-
-    @Override
-    public void reload(ResourceManager manager) {
+    public static void reload(ResourceManager manager) {
         var mapBuilder = ImmutableMap.<Identifier, byte[]>builder();
         BlockVariantGenerator.iterateOverGroups(materialGroup -> {
             BlockVariantGenerator.iterateOverVariants(materialGroup, (baseBlock, materialBlock) -> {

--- a/src/client/resources/projectv.client.mixins.json
+++ b/src/client/resources/projectv.client.mixins.json
@@ -8,7 +8,5 @@
   "injectors": {
     "defaultRequire": 1
   },
-  "mixins": [
-    "LifecycledResourceManagerImplMixin"
-  ]
+  "mixins": []
 }

--- a/src/main/java/dev/enjarai/projectv/ProjectV.java
+++ b/src/main/java/dev/enjarai/projectv/ProjectV.java
@@ -6,6 +6,7 @@ import dev.enjarai.projectv.pack.PackAdderEvent;
 import net.fabricmc.api.ModInitializer;
 
 import net.minecraft.registry.Registry;
+import net.minecraft.resource.ResourceType;
 import net.minecraft.util.Identifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,7 +26,11 @@ public class ProjectV implements ModInitializer {
 
 		BlockVariantGenerator.registerVariants();
 
-		PackAdderEvent.EVENT.register((managerType, packs) -> packs.add(BlockVariantTagGenerator.PACK));
+		PackAdderEvent.EVENT.register((managerType, packs) -> {
+			if (managerType == ResourceType.SERVER_DATA) {
+				packs.add(BlockVariantTagGenerator.PACK);
+			}
+		});
 	}
 
 	public static Identifier id(String path) {

--- a/src/main/java/dev/enjarai/projectv/mixin/LifecycledResourceManagerImplMixin.java
+++ b/src/main/java/dev/enjarai/projectv/mixin/LifecycledResourceManagerImplMixin.java
@@ -1,4 +1,4 @@
-package dev.enjarai.projectv.mixin.client;
+package dev.enjarai.projectv.mixin;
 
 import dev.enjarai.projectv.pack.PackAdderEvent;
 import net.minecraft.resource.LifecycledResourceManagerImpl;

--- a/src/main/resources/projectv.mixins.json
+++ b/src/main/resources/projectv.mixins.json
@@ -3,6 +3,7 @@
   "package": "dev.enjarai.projectv.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
+    "LifecycledResourceManagerImplMixin",
     "ScreenHandlerMixin",
     "TagManagerLoaderMixin"
   ],


### PR DESCRIPTION
Fix packs being added too late and the pack adder mixin not being applied on servers, remove the `SimpleSynchronousResourceReloadListener` stuff and check for `managerType` in pack adder events.